### PR TITLE
Fix: overnight events (24-48h) shown as all-day (Carbon 3 diffInDays regression)

### DIFF
--- a/src/Entities/LeekDuckEvent.php
+++ b/src/Entities/LeekDuckEvent.php
@@ -74,7 +74,7 @@ class LeekDuckEvent
             startDate: $startDate,
             endDate: $endDate,
             durationInDays: $eventDurationInDays,
-            isFullDay: ($eventDurationInDays > 1),
+            isFullDay: ($eventDurationInDays >= 2),
             extraData: $event['extraData']
         );
     }


### PR DESCRIPTION
## Problem
Events that run overnight — longer than 24h but with real start/end times — are
rendered as all-day blocks, losing their times. Example: the current "Ozone
Ascent" event runs Sat 10:00 → Sun 20:00 on Leek Duck, but appears as a single
all-day event on the Saturday.

This also explains part of the "ends 24 hours early" reports (related to #15): an
all-day event's DTEND is exclusive, so these misclassified events drop their final
day in Google Calendar.

## Root cause
`src/Entities/LeekDuckEvent.php` decides all-day via:

```php
isFullDay: ($eventDurationInDays > 1)
```

`$eventDurationInDays` comes from Carbon's `diffInDays()`. **Carbon 3 changed
`diffIn*()` to return a signed float** instead of a truncated integer. A 34h event
now yields `1.41`, and `1.41 > 1` is `true`, so it flips to all-day. Under Carbon 2
this returned `1`, and `1 > 1` was `false` (correctly timed). The project pins
`nesbot/carbon: ^3.0` (3.0.2), so this is a regression from that upgrade.

## Fix
Compare against whole days. `$duration >= 2` is exactly equivalent to the original
integer intent (`(int)$duration > 1`) while preserving the `float` property:

```php
isFullDay: ($eventDurationInDays >= 2)
```

## Testing
Ran the real generator (`bin/gocal gen`) locally on PHP 8.3 with the pinned
Carbon 3.0.2 against live Leek Duck data:

| | Ozone Ascent (Sat 10:00 → Sun 20:00) |
|---|---|
| Before (`> 1`) | `DTSTART;VALUE=DATE:20260725` / `DTEND;VALUE=DATE:20260726` — all-day ❌ |
| After (`>= 2`) | `DTSTART:20260725T100000` / `DTEND:20260726T200000` — timed ✅ |

Multi-day all-day events (Seasons, week-long events) are unchanged. Against the
current Leek Duck source this reclassifies only genuine overnight events.
