### PR TITLE
Fix: multi-day all-day events end a day early (exclusive iCal DTEND) (#15)

### DIFF
--- a/src/Entities/LeekDuckEvent.php
+++ b/src/Entities/LeekDuckEvent.php
@@ -155,7 +155,7 @@ class LeekDuckEvent
                 starts: $this->startDate
             )
             ->endsAt(
-                ends: $this->endDate
+                ends: $this->isFullDay ? $this->endDate->copy()->addDay() : $this->endDate
             )
             ->withoutTimezone();
 


### PR DESCRIPTION
Fixes #15.

## Problem
Multi-day all-day events end one day earlier than Leek Duck states. For example,
the week-long "Special Anniversary Pikachu Celebration" runs through 2026-07-20,
but the feed makes it end on 07-19 in Google Calendar.

## Root cause
Per RFC 5545, a `DATE`-valued `DTEND` is **exclusive** — it is the first day
*not* included in the event. `asCalendarEvent()` passes the raw end date straight
to the generator, so for a full-day event the final day is dropped by
spec-compliant clients (Google Calendar). Apple Calendar happens to be lenient,
which is why it isn't seen everywhere.

## Fix
For full-day events only, advance the end date by one day so the exclusive
`DTEND` lands correctly. Timed events are untouched:

```php
->endsAt(
    ends: $this->isFullDay ? $this->endDate->copy()->addDay() : $this->endDate
)
```

## Testing
Ran the real generator (`bin/gocal gen`) on PHP 8.3 against live Leek Duck data:

| Event | Before | After |
|---|---|---|
| Pikachu (week-long, ends 07-20) | `DTEND;VALUE=DATE:20260720` (ends 07-19) ❌ | `DTEND;VALUE=DATE:20260721` (ends 07-20) ✅ |
| Timed events | unchanged | unchanged |

## Note
For the rare event that ends exactly at midnight, `+1 day` would include one
extra day. None of the current Leek Duck events hit that, and it is still an
improvement over the current always-a-day-early behaviour — happy to refine to
key off the end time if you'd prefer.

This is independent of #17 (the Carbon 3 `diffInDays` all-day regression); the two
fixes compose cleanly.
